### PR TITLE
Fix SonarCloud CI configuration

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
 
       - name: Download test artifacts
@@ -33,7 +35,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=catch-oss_abc-silverstripe
+sonar.organization=catch-design
+sonar.sources=src/abc/code/
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+sonar.php.coverage.reportPaths=coverage/php/coverage.xml
+sonar.php.tests.reportPath=coverage/php/junit.xml
+sonar.exclusions=vendor/**,tests/**


### PR DESCRIPTION
## Summary
- Remove `args` block from sonar.yml that relied on `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` secrets
- Add `repository` and `ref` to checkout step so workflow_run events check out the correct code
- Add `sonar-project.properties` with project key, organization, source/test dirs, and coverage paths

## Test plan
- [ ] Verify SonarCloud scan runs successfully on next push/PR
- [ ] Confirm coverage and test reports are picked up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)