### PR TITLE
Add url_segment to AbcModelAdmin for SS6

### DIFF
--- a/src/abc/code/Admin/AbcModelAdmin.php
+++ b/src/abc/code/Admin/AbcModelAdmin.php
@@ -21,6 +21,8 @@ use SilverStripe\Model\List\ArrayList;
 class AbcModelAdmin extends ModelAdmin
 {
 
+	private static string $url_segment = 'abc-admin';
+
 	/**
 	 * This method generates the list view form
 	 * Individual items are handled by the gridfielddetailform - this is is defined in GridFieldDetailForm_ItemRequest::ItemEditForm() and has been overloaded in the subclass


### PR DESCRIPTION
## Summary
- SS6 requires all `AdminController`/`ModelAdmin` subclasses to define a `url_segment` config property
- Adds `private static string $url_segment = 'abc-admin'` to `AbcModelAdmin`

## Test plan
- [x] CMS loads without `BadMethodCallException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)